### PR TITLE
Change mozutheme:compile to mozutheme:fullcompile

### DIFF
--- a/generators/app/gruntfile-config.json
+++ b/generators/app/gruntfile-config.json
@@ -92,7 +92,7 @@
       "check": {
         "command": "check"
       },
-      "compile": {
+      "fullcompile": {
         "command": "compile"
       },
       "quickcompile": {


### PR DESCRIPTION
Fixes #1.

This matches the contents of Mozu/core-theme's Gruntfile.js, so generating a theme based on it will allow `grunt build-production` to Just Work.