### PR TITLE
Don't upload any '*.orig' files

### DIFF
--- a/generators/app/gruntfile-config.json
+++ b/generators/app/gruntfile-config.json
@@ -39,7 +39,7 @@
           "templates/**/*",
           "*thumb.png",
           "*thumb.jpg",
-          "!*.orig",
+          "!**/*.orig",
           "!.inherited"
         ],
         "tasks": [
@@ -70,7 +70,7 @@
           "*thumb.png",
           "*thumb.jpg",
           "theme-ui.json",
-          "!*.orig",
+          "!**/*.orig",
           "!.inherited"
         ]
       },


### PR DESCRIPTION
The current configuration prevents files created by git merge conflicts (ending in `*.orig`) from being uploaded to Kibo, but only if they are in the root directory of the theme. This change excludes all `*.orig` files anywhere.

This is important especially for template files, because Hypr will load a `*.hypr.orig` file over a `*.hypr` file, displaying the conflict markers on the site.